### PR TITLE
Fixed carbon-cache startup issues

### DIFF
--- a/config/Dockerfile
+++ b/config/Dockerfile
@@ -36,6 +36,9 @@ RUN pip install graphite-api[sentry] whisper carbon
 # http://graphite-api.readthedocs.org/en/latest/installation.html#extra-dependencies
 # RUN pip install -y graphite-api[cache]
 
+# Fix issues with carbon-cache by upgrading it
+RUN pip install --upgrade carbon
+
 # Graphite
 COPY carbon.conf /opt/graphite/conf/carbon.conf
 COPY storage-schemas.conf /opt/graphite/conf/storage-schemas.conf


### PR DESCRIPTION
Carbon-cache fails to start and needs an update. I added this to the Dockerfile. Now works after a fresh build. 

For further info about the issue see this link:
https://github.com/jedimt/hcicollector/issues/8